### PR TITLE
build: Add Hilt dependencies to core/data

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
+    id("com.google.dagger.hilt.android")
+    id("kotlin-kapt")
 }
 
 android {
@@ -42,15 +44,18 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+//    retrofit and OkHttp
     implementation(libs.converter.gson)
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation(libs.okhttp.loggingInterceptor)
+//    hilt dependencies
+    implementation(libs.hilt.android)
+    kapt(libs.hilt.compiler)
+
     implementation(libs.androidx.runtime)
     implementation(libs.androidx.lifecycle.viewmodel.android)
     implementation(libs.androidx.lifecycle.viewmodel.android)
     implementation(libs.androidx.espresso.core)
-    implementation(libs.hilt.android)
-    implementation(libs.hilt.android)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)


### PR DESCRIPTION
This commit adds the Hilt Gradle plugin and dependencies to the `core/data` module. It also includes the `kotlin-kapt` plugin.

Additionally, comments have been added to group Retrofit/OkHttp and Hilt dependencies for better readability. Duplicate Hilt implementation lines were removed.