### PR TITLE
Refactor: Update networking configuration and clean up UI manifest

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,49 @@
+{
+  "project_info": {
+    "project_number": "245929255945",
+    "firebase_url": "https://fir-workout-c94f5-default-rtdb.firebaseio.com",
+    "project_id": "fir-workout-c94f5",
+    "storage_bucket": "fir-workout-c94f5.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:245929255945:android:fee38643a2ecbac49484d8",
+        "android_client_info": {
+          "package_name": "com.Mark.Sajili"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBRe3lxxnIpSMTrKJ8w5Dz4aawT21KbWqs"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:245929255945:android:0d127fae88047f1e9484d8",
+        "android_client_info": {
+          "package_name": "com.example.hotel"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBRe3lxxnIpSMTrKJ8w5Dz4aawT21KbWqs"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <application
         android:name=".MainApplication"
         android:allowBackup="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/core/data/src/main/java/com/mark/data/Network Module.kt
+++ b/core/data/src/main/java/com/mark/data/Network Module.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Named
 import javax.inject.Singleton
 
-const val BASE_URL= "http://postgres-production-45b8.up.railway.app"
+const val BASE_URL= "192.168.100.5"
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -34,7 +34,6 @@ object NetworkModule{
     @Provides
     fun provideGSON(): Gson {
         return GsonBuilder()
-            .setLenient()
             .create()
     }
 

--- a/core/data/src/main/res/xml/network_security_config.xml
+++ b/core/data/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">192.168.100.5</domain>
+    </domain-config>
+</network-security-config>

--- a/core/ui/src/main/AndroidManifest.xml
+++ b/core/ui/src/main/AndroidManifest.xml
@@ -1,45 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.mark.ui"
+    >
 
     <application>
-        <activity
-            android:name=".ConfirmPopUp"
-            android:exported="false"
-            android:label="@string/title_activity_confirm_pop_up"
-            android:theme="@style/Theme.Sajili" />
-        <activity
-            android:name=".kyc.verify"
-            android:exported="false"
-            android:label="@string/title_activity_verify"
-            android:theme="@style/Theme.Sajili" />
+
+
         <activity
             android:name=".kyc.NewUserReg"
             android:exported="false"
             android:label="@string/title_activity_new_user_reg"
             android:theme="@style/Theme.Sajili" />
-        <activity
-            android:name=".KycIntro.ServiceSelectionKyc"
-            android:exported="false"
-            android:label="@string/title_activity_service_selection_kyc"
-            android:theme="@style/Theme.Sajili" />
-        <activity
-            android:name=".KycIntro.KycIntroScreen"
-            android:exported="false"
-            android:label="@string/title_activity_kyc_intro_screen"
-            android:theme="@style/Theme.Sajili" />
+
+
         <activity
             android:name=".CustomerDashboard.CustomerServiceActivity"
             android:exported="false"
             android:label="@string/title_activity_customer_service"
             android:theme="@style/Theme.Sajili" />
-        <activity
-            android:name=".RegistrationScreen"
-            android:exported="false"
-            android:label="@string/title_activity_registration_screen"
-            android:theme="@style/Theme.Sajili" />
-        <activity
-            android:name=".LoginScreen"
-            android:exported="false" />
+
+
     </application>
 
 </manifest>

--- a/core/ui/src/main/java/com/mark/ui/ConfirmPopUp.kt
+++ b/core/ui/src/main/java/com/mark/ui/ConfirmPopUp.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.currentRecomposeScope
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.text.input.KeyboardType
@@ -47,9 +48,11 @@ fun ConfirmPopUp(
     val authState by viewModel.authState.collectAsStateWithLifecycle()
     val isLoading = authState is AuthResult.Loading
 //    LaunchedEffect to handle navigation after successful verification
+    //passing the backend-generated JWT TO MY NAVIGATION
     LaunchedEffect(key1 = authState) {
-        if (authState is AuthResult.Success) {
-            val token = (authState as AuthResult.Success).idToken ?: ""
+        val currentState=authState
+        if (currentState is AuthResult.Success) {
+            val token = currentState.authResponse?.jwt.orEmpty()
             onVerificationSuccess(token)
             viewModel.clearAuthStates()
         }


### PR DESCRIPTION
This commit updates the networking setup to use a local development server and refactors the `core/ui` manifest for better organization.

Key changes include:
- **Networking**: Added a `network_security_config.xml` to permit cleartext traffic for a specific local IP (`192.168.100.5`) and updated `BASE_URL` in `Network Module.kt` to match.
- **Data**: Removed `.setLenient()` from Gson configuration in `Network Module.kt`.
- **UI & Manifest**:
    - Simplified `core/ui/src/main/AndroidManifest.xml` by removing several activity declarations (including `ConfirmPopUp`, `verify`, and `LoginScreen`).
    - Added the package name explicitly to the `core/ui` manifest.
- **Logic**: Updated `ConfirmPopUp.kt` to extract the JWT from the `authResponse` object instead of an `idToken` during successful verification.