### PR TITLE
Refactor: Integrate Hilt for ViewModel injection and update Auth flow

### DIFF
--- a/app/src/main/java/com/mark/sajili/MainActivity.kt
+++ b/app/src/main/java/com/mark/sajili/MainActivity.kt
@@ -6,7 +6,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -36,8 +35,10 @@ fun MainApp(){
     val navController= rememberNavController()
     val authViewModel: AuthViewModel= hiltViewModel()
     NavHost(navController= navController, startDestination= AuthAgentDestination.LOGIN_ROUTE){
+
         composable(AuthAgentDestination.CONFIRM_OTP_ROUTE){
             ConfirmPopUp(
+                viewModel=authViewModel,
                 onVerificationSuccess = { jwtToken ->
                     navController.navigate(AuthAgentDestination.CUSTOMER_DASHBOARD_ROUTE) {
                         popUpTo(AuthAgentDestination.LOGIN_ROUTE) { inclusive = true }
@@ -46,7 +47,6 @@ fun MainApp(){
                 onNavigateToLogin = {
                     navController.navigate(AuthAgentDestination.LOGIN_ROUTE)
                 },
-                viewModel = TODO()
             )
         }
 
@@ -54,6 +54,7 @@ fun MainApp(){
 
     composable(AuthAgentDestination.LOGIN_ROUTE){
         LoginScreen(
+            viewModel = authViewModel,
             onLoginSuccess ={_, _ ->
 //                on successful login navigate to the customer dashboard
                 navController.navigate(AuthAgentDestination.CUSTOMER_DASHBOARD_ROUTE){
@@ -93,9 +94,7 @@ fun MainApp(){
     }
 //        Composable for the Registration Screen,
         composable(AuthAgentDestination.CUSTOMER_DASHBOARD_ROUTE){
-            CustomerDashboardScreen(
-                profileService = TODO()
-            )
+            CustomerDashboardScreen()
         }
 
     }

--- a/core/data/src/main/java/com/mark/data/AuthResponse.kt
+++ b/core/data/src/main/java/com/mark/data/AuthResponse.kt
@@ -3,8 +3,9 @@ package com.mark.data
 import com.google.gson.annotations.SerializedName
 
 data class AuthResponse(
-    val jwt:String?=null,
-    val phoneNumber: String?=null
+    val phoneNumber: String?=null,
+    @SerializedName("jwtToken")
+    val jwtToken:String?=null
 )
 
 data class ErrorResponse(

--- a/core/data/src/main/java/com/mark/data/Network Module.kt
+++ b/core/data/src/main/java/com/mark/data/Network Module.kt
@@ -119,9 +119,7 @@ object NetworkModule{
                 val errorBodyString= response.errorBody()?.string()
                 val errorResponse= try{
                     gson.fromJson(errorBodyString, ErrorResponse::class.java)
-                } catch (e:Exception){
-                    null
-                }
+                } catch (e:Exception){ null }
                 val errorMessage= errorResponse?.message ?:"Unknown error occurred"
                 Result.failure(SajiliApiException(errorMessage, response.code(),errorResponse))
             }

--- a/core/ui/src/main/java/com/mark/ui/AuthResult.kt
+++ b/core/ui/src/main/java/com/mark/ui/AuthResult.kt
@@ -72,9 +72,15 @@ val authState=_authState.asStateFlow()
         )
         //executes a backend call safely
         val result = safeApiCall { authService.register(request) }
-        result.onSuccess{
+        result.onSuccess{response->
 //        this success state is what triggers the Pop-up in the UI
-                authResponse-> _authState.value= AuthResult.Success("Registration Successful!", authResponse)
+
+            _authState.value= AuthResult.Success("Registration Successful!", response)
+            response.jwtToken?.let { token ->
+                tokenRepository.saveToken(token)
+                jwtToken = token
+                isAuthenticated = true
+            }
             pinInput=""
         }.onFailure {throwable->
             _authState.value= AuthResult.Error(throwable.message?: "Registration Failed", null)
@@ -113,6 +119,8 @@ val authState=_authState.asStateFlow()
     PhoneAuthProvider.verifyPhoneNumber(options)
     }
     fun verifySmsCode(){
+        println("DEBUG: verifySmsCode called. ID: $verificationId, Code: $smsCodeInput")
+
         _authState.value= AuthResult.Loading
         if (verificationId== null  || smsCodeInput.isBlank()){
             _authState.value= AuthResult.Error("Sms Code orVerification Id is missing",null)
@@ -149,7 +157,7 @@ val authState=_authState.asStateFlow()
         val request= FirebaseTokenRequest(idToken)
         val result = safeApiCall { authService.verifyToken(request) }
         result.onSuccess { authResponse->
-            val newJwtToken= authResponse.jwt
+            val newJwtToken= authResponse.jwtToken
             if(newJwtToken != null){
                 tokenRepository.saveToken(newJwtToken)
                 jwtToken= newJwtToken

--- a/core/ui/src/main/java/com/mark/ui/ConfirmPopUp.kt
+++ b/core/ui/src/main/java/com/mark/ui/ConfirmPopUp.kt
@@ -1,5 +1,6 @@
 package com.mark.ui
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -22,21 +23,21 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.currentRecomposeScope
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+
+
 //its a user interface to enter the 6 digit code received via sms from Firebase
 @Composable
 fun ConfirmPopUp(
@@ -45,6 +46,7 @@ fun ConfirmPopUp(
     onNavigateToLogin: () -> Unit,
     viewModel: AuthViewModel
 ) {
+    val context= LocalContext.current
     val authState by viewModel.authState.collectAsStateWithLifecycle()
     val isLoading = authState is AuthResult.Loading
 //    LaunchedEffect to handle navigation after successful verification
@@ -52,10 +54,12 @@ fun ConfirmPopUp(
     LaunchedEffect(key1 = authState) {
         when (authState){
             is AuthResult.Success ->{
-                val token = (authState as AuthResult.Success).authResponse?.jwt.orEmpty()
+                val token = (authState as AuthResult.Success).authResponse?.jwtToken.orEmpty()
                 onVerificationSuccess(token)
             }
             is AuthResult.Error ->{
+                val errorMessage = (authState as AuthResult.Error).message
+                Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
                 println("Backend/Firebase Error: ${authState as AuthResult.Error}.message")
             }
             else -> {}

--- a/core/ui/src/main/java/com/mark/ui/CustomerDashboard/CustomerProfileViewModel.kt
+++ b/core/ui/src/main/java/com/mark/ui/CustomerDashboard/CustomerProfileViewModel.kt
@@ -3,11 +3,14 @@ package com.mark.ui.CustomerDashboard
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mark.data.Profile
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class CustomerProfileViewModel(
+@HiltViewModel
+class CustomerProfileViewModel @Inject constructor(
     private val profileService: Profile
 ): ViewModel(){
     private val _uiState = MutableStateFlow<ProfileUiState>(ProfileUiState.Loading)

--- a/core/ui/src/main/java/com/mark/ui/CustomerDashboard/CustomerService.kt
+++ b/core/ui/src/main/java/com/mark/ui/CustomerDashboard/CustomerService.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.mark.data.Profile
 
@@ -77,9 +78,8 @@ class CustomerServiceActivity: ComponentActivity(){
 }
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CustomerDashboardScreen(profileService: Profile) {
-    val factory = CustomerProfileViewModelFactory(profileService)
-    val viewModel: CustomerProfileViewModel = viewModel(factory= factory)
+fun CustomerDashboardScreen(viewModel:CustomerProfileViewModel= hiltViewModel()) {
+
     val  uiState by viewModel.uiState.collectAsState()
     //scaffold is a pre-defined material design layout structure
     //it gives you slots for common screen elements
@@ -330,15 +330,6 @@ fun CustomerServiceGridItem(item: CustomerServiceItem) {
 //create a fake or mock instance of ProfileServiceImpl
 //the @preview environment is specifically designed to render my composable in isolation
 //without running the full application lifecycle
-@Preview(showBackground = true)
-@Composable
-fun CustomerScreenPreview(){
-    //we can't use demoprofileview directly
-    //since demoprofilepreview is a class and doesn't have a companion object
-    //we need to create an instance of it
-    val demoServiceInstance = DemoProfilePreview()
-    CustomerDashboardScreen(profileService = demoServiceInstance)
-}
 
 
 


### PR DESCRIPTION
This commit refactors the navigation and dependency injection logic to fully utilize Hilt across the UI and Data modules.

Key changes include:
- **Dependency Injection**: Added `@HiltViewModel` and `@Inject` to `CustomerProfileViewModel`. Updated `MainActivity.kt` and `CustomerService.kt` to use `hiltViewModel()` instead of manual factory instantiation.
- **Authentication Logic**:
    - Updated `AuthResult.kt` to automatically save the JWT token to the repository upon successful registration.
    - Standardized naming from `jwt` to `jwtToken` in `AuthResponse.kt` and across the auth flow.
    - Improved `ConfirmPopUp.kt` with a Toast message to display backend/Firebase errors to the user.
- **UI & Cleanup**:
    - Simplified `CustomerDashboardScreen` by removing the manual `profileService` dependency and unused preview code.
    - Fixed a bug where `LoginScreen` and `ConfirmPopUp` were missing the shared `AuthViewModel` instance in `MainActivity.kt`.
    - Added debug logging for SMS verification.
- **Data**: Updated `AuthResponse` with `@SerializedName("jwtToken")` to ensure correct GSON mapping.